### PR TITLE
Add check for Python 3

### DIFF
--- a/SNPMeta.py
+++ b/SNPMeta.py
@@ -10,6 +10,10 @@ import sys
 import os
 import time
 
+#   Make sure we are running Python 3
+if sys.version_info.major is not 3:
+    sys.exit('This script requires Python 3')
+
 #   Try to import the Biopython library
 try:
     import Bio


### PR DESCRIPTION
Add a simple check to see if we're using Python 3 as `urllib.error` is only available in Python 3. This provides a cleaner and more informative error message than :

``` python
Traceback (most recent call last):
  File "SNPMeta.py", line 26, in <module>
    from snpmeta.SNPAnnotation.blast_search import BlastSearch
  File "/panfs/roc/groups/9/morrellp/goggi015/SNPMeta/snpmeta/SNPAnnotation/blast_search.py", line 8, in <module>
    from urllib.error import HTTPError
ImportError: No module named error
```
